### PR TITLE
Fix prepare husky command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "ci-checks": "eslint . && prettier --check . && npm run type-check && npm run deps-check",
     "deps-check": "knip",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "node --test",
     "type-check": "tsc"
   },


### PR DESCRIPTION
When installing the dependencies after cloning the repo, there's a warning message stating

> husky - install command is DEPRECATED

<img width="782" height="250" alt="image" src="https://github.com/user-attachments/assets/7b892a79-02b5-4966-95f6-ec8bb54c657f" />


This is because the appropriate command in `prepare` should be just `husky`. This PR fixes that